### PR TITLE
Port information added

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,10 @@ To run this sample, you'll need a Bandwidth phone number, Voice API credentials 
 
 This sample will need be publicly accessible to the internet in order for Bandwidth API callbacks to work properly. Otherwise you'll need a tool like [ngrok](https://ngrok.com) to provide access from Bandwidth API callbacks to localhost.
 
+```
+./ngrok http 3000
+```
+> Note: This app was hardcoded to run on  `http://localhost:3000`. If you want to run it on a different port, you must change the port in both `server.js` and `public/index.html`.
 ### Create a Bandwidth Voice API application
 
 Follow the steps in [How to Create a Voice API Application](https://support.bandwidth.com/hc/en-us/articles/360035060934-How-to-Create-a-Voice-API-Application-V2-) to create your Voice API appliation.

--- a/public/index.html
+++ b/public/index.html
@@ -4,7 +4,8 @@
     <!-- we recommend hosting this yourself, github is not always the best CDN -->
     <script src="https://github.com/Bandwidth/webrtc-browser/releases/download/0.9.1/BandwidthRtc.bundle.js"></script>
     <script language="javascript">
-      const basePath = "http://localhost:3000";
+      const port = 3000;
+      const basePath = "http://localhost:"+port;
       const bandwidthRtc = new BandwidthRtc();
 
       /**


### PR DESCRIPTION
- Clarified that the app is hardcoded to run on localhost:3000
- Added a variable in index.html to change the port if desired

I changed this because I couldn't get my app to work until I realized that this example was running on port 3000, not 5000. Other example apps (like conference-node) run on port 5000 by default, leading to the confusion.